### PR TITLE
Add video output

### DIFF
--- a/include/blackmagic_camera_driver/bmd_handle.hpp
+++ b/include/blackmagic_camera_driver/bmd_handle.hpp
@@ -41,8 +41,9 @@ public:
   {
     if (bmd_item_ != nullptr)
     {
-      const auto new_refcount = bmd_item_->Release();
-      std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " called Release() with resulting refcount " << new_refcount << std::endl;
+      bmd_item_->Release();
+      // const auto new_refcount = bmd_item_->Release();
+      // std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " called Release() with resulting refcount " << new_refcount << std::endl;
     }
     bmd_item_ = bmd_item;
     if (bmd_item_ != nullptr)
@@ -50,8 +51,9 @@ public:
       const auto new_refcount = bmd_item_->AddRef();
       if (new_refcount > 1)
       {
-        const auto item_refcount = bmd_item_->Release();
-        std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " created/reset with refcount " << item_refcount << std::endl;
+        bmd_item_->Release();
+        // const auto item_refcount = bmd_item_->Release();
+        // std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " created/reset with refcount " << item_refcount << std::endl;
       }
       else
       {

--- a/include/blackmagic_camera_driver/bmd_handle.hpp
+++ b/include/blackmagic_camera_driver/bmd_handle.hpp
@@ -4,20 +4,108 @@
 
 namespace blackmagic_camera_driver
 {
+// Managed pointer type like std::unique_ptr, but aware of BMD's AddRef/Release
+// reference counting system.
 template<typename BMDType>
-class BMDDeleter
+class BMDHandle
 {
 public:
-  void operator()(BMDType* ptr) const
+  explicit BMDHandle(BMDType* bmd_item)
   {
-    if (ptr != nullptr)
+    if (bmd_item != nullptr)
     {
-      ptr->Release();
+      reset(bmd_item);
+    }
+    else
+    {
+      throw std::invalid_argument("BMDHandle constructed with nullptr");
     }
   }
+
+  BMDHandle(const BMDHandle<BMDType>& other) = delete;
+
+  BMDHandle(BMDHandle<BMDType>&& other)
+  {
+    reset(nullptr);
+    bmd_item_ = other.release();
+  }
+
+  BMDHandle() : bmd_item_(nullptr) {}
+
+  ~BMDHandle()
+  {
+    reset(nullptr);
+  }
+
+  void reset(BMDType* bmd_item = nullptr)
+  {
+    if (bmd_item_ != nullptr)
+    {
+      const auto new_refcount = bmd_item_->Release();
+      std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " called Release() with resulting refcount " << new_refcount << std::endl;
+    }
+    bmd_item_ = bmd_item;
+    if (bmd_item_ != nullptr)
+    {
+      const auto new_refcount = bmd_item_->AddRef();
+      if (new_refcount > 1)
+      {
+        const auto item_refcount = bmd_item_->Release();
+        std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " created/reset with refcount " << item_refcount << std::endl;
+      }
+      else
+      {
+        std::cout << "[BMDHandle<" << typeid(BMDType).name() << ">] with item " << bmd_item_ << " created/reset with zero refcount" << std::endl;
+        throw std::runtime_error("Creating a handle with zero refcount is a BUG!");
+      }
+    }
+  }
+
+  BMDType* release()
+  {
+    BMDType* const item = bmd_item_;
+    bmd_item_ = nullptr;
+    return item;
+  }
+
+  BMDType* get() const { return bmd_item_; }
+
+  BMDType* operator->() const
+  {
+    if (bmd_item_ != nullptr)
+    {
+      return get();
+    }
+    else
+    {
+      throw std::runtime_error("Contained BMDType is nullptr");
+    }
+  }
+
+  typename std::add_lvalue_reference<BMDType>::type operator*() const
+  {
+    if (bmd_item_ != nullptr)
+    {
+      return *get();
+    }
+    else
+    {
+      throw std::runtime_error("Contained BMDType is nullptr");
+    }
+  }
+
+  BMDHandle<BMDType>& operator=(const BMDHandle<BMDType>& other) = delete;
+
+  BMDHandle<BMDType>& operator=(BMDHandle<BMDType>&& other)
+  {
+    reset(nullptr);
+    bmd_item_ = other.release();
+    return *this;
+  }
+
+  explicit operator bool() const { return bmd_item_ != nullptr; }
+
+private:
+  BMDType* bmd_item_ = nullptr;
 };
-
-template<typename BMDType>
-using BMDHandle = std::unique_ptr<BMDType, BMDDeleter<BMDType>>;
 }  // namespace blackmagic_camera_driver
-

--- a/include/blackmagic_camera_driver/decklink_interface.hpp
+++ b/include/blackmagic_camera_driver/decklink_interface.hpp
@@ -50,6 +50,11 @@ inline int16_t ConvertToFixed16(const float val)
   return static_cast<int16_t>(multiplied);
 }
 
+inline int32_t Calc10BitYUVRowBytes(const int32_t frame_width)
+{
+  return ((frame_width + 47) / 48) * 128;
+}
+
 template<typename T>
 std::string HexPrint(const T& val)
 {

--- a/include/blackmagic_camera_driver/decklink_interface.hpp
+++ b/include/blackmagic_camera_driver/decklink_interface.hpp
@@ -86,7 +86,7 @@ class FrameReceivedCallback : public IDeckLinkInputCallback
 {
 public:
   FrameReceivedCallback(DeckLinkDevice* parent_device)
-      : parent_device_(parent_device), refcount_(1)
+      : parent_device_(parent_device)
   {
     if (parent_device_ == nullptr)
     {
@@ -129,14 +129,14 @@ public:
 
 private:
   DeckLinkDevice* parent_device_ = nullptr;
-  std::atomic<uint64_t> refcount_{};
+  std::atomic<uint64_t> refcount_{1};
 };
 
 class FrameOutputCallback : public IDeckLinkVideoOutputCallback
 {
 public:
   FrameOutputCallback(DeckLinkDevice* parent_device)
-      : parent_device_(parent_device), refcount_(1)
+      : parent_device_(parent_device)
   {
     if (parent_device_ == nullptr)
     {
@@ -176,7 +176,7 @@ public:
 
 private:
   DeckLinkDevice* parent_device_ = nullptr;
-  std::atomic<uint64_t> refcount_{};
+  std::atomic<uint64_t> refcount_{1};
 };
 
 class BlackmagicSDICameraControlMessage
@@ -468,7 +468,7 @@ private:
   const uint8_t sdid_ = 0x53;
   const uint32_t line_number_ = 16;
   const uint8_t data_stream_index_ = 0x00;
-  std::atomic<uint64_t> refcount_{};
+  std::atomic<uint64_t> refcount_{1};
 };
 
 class BlackmagicSDITallyControlPacket : public IDeckLinkAncillaryPacket
@@ -544,7 +544,7 @@ private:
   const uint8_t sdid_ = 0x52;
   const uint32_t line_number_ = 15;
   const uint8_t data_stream_index_ = 0x00;
-  std::atomic<uint64_t> refcount_{};
+  std::atomic<uint64_t> refcount_{1};
 };
 
 class DeckLinkDevice

--- a/include/blackmagic_camera_driver/decklink_interface.hpp
+++ b/include/blackmagic_camera_driver/decklink_interface.hpp
@@ -55,6 +55,11 @@ inline int32_t Calc10BitYUVRowBytes(const int32_t frame_width)
   return ((frame_width + 47) / 48) * 128;
 }
 
+// Enforces that video frames are the same size (# of bytes).
+void CopyVideoFrameBytes(
+    const IDeckLinkVideoFrame& source_frame,
+    IDeckLinkMutableVideoFrame& destination_frame);
+
 template<typename T>
 std::string HexPrint(const T& val)
 {

--- a/include/blackmagic_camera_driver/decklink_interface.hpp
+++ b/include/blackmagic_camera_driver/decklink_interface.hpp
@@ -576,6 +576,14 @@ public:
 
   void EnqueueCameraCommand(const BlackmagicSDICameraControlMessage& command);
 
+  void ClearOutputQueueAndResetOutputToReferenceFrame();
+
+  void EnqueueOutputFrame(DeckLinkMutableVideoFrameHandle output_frame);
+
+  DeckLinkMutableVideoFrameHandle CreateBGRA8OutputVideoFrame();
+
+  DeckLinkMutableVideoFrameHandle CreateYUV10OutputVideoFrame();
+
   void Log(
       const LogLevel level, const std::string& message,
       const bool throttle = false)
@@ -673,15 +681,20 @@ private:
 
   BMDDisplayMode output_display_mode_ = bmdModeHD1080p30;
 
+  std::mutex output_frame_queue_lock_;
+  std::list<DeckLinkMutableVideoFrameHandle> output_frame_queue_;
+
   DeckLinkHandle device_;
   DeckLinkProfileAttributesHandle attributes_interface_;
   DeckLinkInputHandle input_device_;
   DeckLinkOutputHandle output_device_;
-  DeckLinkVideoConversionHandle video_converter_;
+  DeckLinkVideoConversionHandle input_video_converter_;
+  DeckLinkVideoConversionHandle output_video_converter_;
   DeckLinkInputCallbackHandle input_callback_;
   DeckLinkOutputCallbackHandle output_callback_;
-  DeckLinkMutableVideoFrameHandle conversion_frame_;
+  DeckLinkMutableVideoFrameHandle input_conversion_frame_;
   DeckLinkMutableVideoFrameHandle reference_output_frame_;
+  DeckLinkMutableVideoFrameHandle active_output_frame_;
   DeckLinkMutableVideoFrameHandle command_output_frame_;
 };
 

--- a/include/blackmagic_camera_driver/decklink_interface.hpp
+++ b/include/blackmagic_camera_driver/decklink_interface.hpp
@@ -566,7 +566,7 @@ public:
           video_frame_size_changed_callback_fn,
       const ConvertedVideoFrameCallbackFunction&
           converted_video_frame_callback_fn,
-      DeckLinkHandle device);
+      const BMDDisplayMode output_mode, DeckLinkHandle device);
 
   virtual ~DeckLinkDevice() {}
 
@@ -670,6 +670,8 @@ private:
   int64_t output_frame_counter_ = 0;
   int64_t output_frame_duration_ = 0;
   int64_t output_frame_timescale_ = 0;
+
+  BMDDisplayMode output_display_mode_ = bmdModeHD1080p30;
 
   DeckLinkHandle device_;
   DeckLinkProfileAttributesHandle attributes_interface_;

--- a/src/blackmagic_camera_driver/decklink_interface.cpp
+++ b/src/blackmagic_camera_driver/decklink_interface.cpp
@@ -863,13 +863,6 @@ HRESULT DeckLinkDevice::ScheduledFrameCallback(
   {
     throw std::runtime_error("Failed to attach tally control packet");
   }
-  // Not sure why this is necessary - Blackmagic's examples suggest that
-  // AttachPacket doesn't bump refcount, so we don't want the unique_ptr
-  // destructor to get rid of the tally packet.
-  else
-  {
-    tally_packet.release();
-  }
 
   // Add a control packet
   if (control_packet)
@@ -880,13 +873,6 @@ HRESULT DeckLinkDevice::ScheduledFrameCallback(
     if (add_control_packet_result != S_OK)
     {
       throw std::runtime_error("Failed to attach camera control packet");
-    }
-    // Not sure why this is necessary - Blackmagic's examples suggest that
-    // AttachPacket doesn't bump refcount, so we don't want the unique_ptr
-    // destructor to get rid of the control packet.
-    else
-    {
-      control_packet.release();
     }
   }
   return ScheduleNextFrame(*command_output_frame_);

--- a/src/blackmagic_camera_driver/decklink_interface.cpp
+++ b/src/blackmagic_camera_driver/decklink_interface.cpp
@@ -90,8 +90,6 @@ void CopyVideoFrameBytes(
     throw std::runtime_error("Failed to get destination frame bytes");
   }
 
-  // std::cout << "[CopyVideoFrameBytes] memcpy-ing " << destination_frame_bytes << " bytes from " << source_frame_buffer << " to " << destination_frame_buffer << std::endl;
-
   // Copy frame data
   std::memcpy(
       destination_frame_buffer, source_frame_buffer, destination_frame_bytes);
@@ -409,8 +407,6 @@ DeckLinkDevice::DeckLinkDevice(
   {
     throw std::runtime_error("Failed to create output video converter");
   }
-
-  std::cout << "Created video converters " << input_video_converter_.get() << " (input) " << output_video_converter_.get() << " (output)" << std::endl;
 
   // We have to setup the conversion frames with defaults, since we will not get
   // an input format changed notification if the real input matches the

--- a/src/blackmagic_camera_driver_node.cpp
+++ b/src/blackmagic_camera_driver_node.cpp
@@ -81,6 +81,7 @@ public:
         LoggingFunction(RosLoggingFunction),
         video_frame_size_changed_callback_fn,
         converted_video_frame_callback_fn,
+        bmdModeHD1080p30,
         std::move(device)));
   }
 

--- a/src/blackmagic_camera_driver_node.cpp
+++ b/src/blackmagic_camera_driver_node.cpp
@@ -96,9 +96,7 @@ public:
 
   void EnqueueOutputFrame(DeckLinkMutableVideoFrameHandle output_frame)
   {
-    std::cout << "Enqueueing new output frame..." << std::endl;
     decklink_device_->EnqueueOutputFrame(std::move(output_frame));
-    std::cout << "...new output frame enqueued" << std::endl;
   }
 
   void ClearOutputQueueAndResetOutputToReferenceFrame()
@@ -276,23 +274,19 @@ int DoMain()
     if (tick == 30)
     {
       image_data_ptr = red_color.data();
-      std::cout << "Setting output frame to red" << std::endl;
     }
     else if (tick == 60)
     {
       image_data_ptr = green_color.data();
-      std::cout << "Setting output frame to green" << std::endl;
     }
     else if (tick == 90)
     {
       image_data_ptr = blue_color.data();
-      std::cout << "Setting output frame to blue" << std::endl;
       tick = 0;
     }
 
     if (image_data_ptr != nullptr)
     {
-      std::cout << "Creating output frame" << std::endl;
       auto output_frame = capture_device.CreateBGRA8OutputVideoFrame();
       uint8_t* output_frame_buffer = nullptr;
       const auto get_output_bytes_result = output_frame->GetBytes(

--- a/src/blackmagic_camera_driver_node.cpp
+++ b/src/blackmagic_camera_driver_node.cpp
@@ -94,6 +94,23 @@ public:
     decklink_device_->EnqueueCameraCommand(command);
   }
 
+  void EnqueueOutputFrame(DeckLinkMutableVideoFrameHandle output_frame)
+  {
+    std::cout << "Enqueueing new output frame..." << std::endl;
+    decklink_device_->EnqueueOutputFrame(std::move(output_frame));
+    std::cout << "...new output frame enqueued" << std::endl;
+  }
+
+  void ClearOutputQueueAndResetOutputToReferenceFrame()
+  {
+    decklink_device_->ClearOutputQueueAndResetOutputToReferenceFrame();
+  }
+
+  DeckLinkMutableVideoFrameHandle CreateBGRA8OutputVideoFrame()
+  {
+    return decklink_device_->CreateBGRA8OutputVideoFrame();
+  }
+
 private:
   void VideoFrameSizeChangedCallback(
       const int32_t image_width, const int32_t image_height,
@@ -241,10 +258,62 @@ int DoMain()
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
 
+  // Make primary color image data blocks
+  const size_t num_image_pixels = 1920 * 1080;
+  const size_t num_image_bytes = num_image_pixels * 4;
+  const std::vector<uint32_t> red_color(num_image_pixels, 0xffff0000);
+  const std::vector<uint32_t> green_color(num_image_pixels, 0xff00ff00);
+  const std::vector<uint32_t> blue_color(num_image_pixels, 0xff0000ff);
+
+  int32_t tick = 0;
   // Spin while video callbacks run
   ros::Rate spin_rate(30.0);
   while (ros::ok())
   {
+    tick++;
+
+    const void* image_data_ptr = nullptr;
+    if (tick == 30)
+    {
+      image_data_ptr = red_color.data();
+      std::cout << "Setting output frame to red" << std::endl;
+    }
+    else if (tick == 60)
+    {
+      image_data_ptr = green_color.data();
+      std::cout << "Setting output frame to green" << std::endl;
+    }
+    else if (tick == 90)
+    {
+      image_data_ptr = blue_color.data();
+      std::cout << "Setting output frame to blue" << std::endl;
+      tick = 0;
+    }
+
+    if (image_data_ptr != nullptr)
+    {
+      std::cout << "Creating output frame" << std::endl;
+      auto output_frame = capture_device.CreateBGRA8OutputVideoFrame();
+      uint8_t* output_frame_buffer = nullptr;
+      const auto get_output_bytes_result = output_frame->GetBytes(
+          reinterpret_cast<void**>(&output_frame_buffer));
+      if (get_output_bytes_result != S_OK || output_frame_buffer == nullptr)
+      {
+        throw std::runtime_error("Failed to get output frame bytes");
+      }
+      const size_t output_frame_bytes
+          = output_frame->GetRowBytes() * output_frame->GetHeight();
+      if (output_frame_bytes != num_image_bytes)
+      {
+        throw std::runtime_error(
+            "Image data and frame data are different sizes");
+      }
+
+      std::memcpy(output_frame_buffer, image_data_ptr, num_image_bytes);
+
+      capture_device.EnqueueOutputFrame(std::move(output_frame));
+    }
+
     ros::spinOnce();
     spin_rate.sleep();
   }


### PR DESCRIPTION
Adds user-controllable video output capabilities (previously a fixed color frame was output to carry SDI camera commands).

Fixes a couple refcount bugs inherited from BMD examples.